### PR TITLE
ci: switch to the official upstream workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: 3.11
 
       - name: Setup Zephyr project
-        uses: fabiobaltieri/zephyr-setup@main
+        uses: zephyrproject-rtos/action-zephyr-setup@v1
         with:
           app-path: artificial-nose-zephyr
           toolchains: arm-zephyr-eabi:xtensa-espressif_esp32_zephyr-elf:xtensa-espressif_esp32s3_zephyr-elf


### PR DESCRIPTION
Switch the build to the official upstream setup-zephyr workflow.